### PR TITLE
enable 13V as mentioned by marian3

### DIFF
--- a/dsqsend/senddsq.c
+++ b/dsqsend/senddsq.c
@@ -16,7 +16,6 @@ int dsend(int fd, char *data) {
 	cmd.msg_len = 0;
 	int p = 0, processed;
 	unsigned char d;
-
 	while(sscanf(&data[p], "%02hhx %n", &d, &processed) == 1) {
 		if(cmd.msg_len < sizeof(cmd.msg)) {
 			printf("%02X ", d);
@@ -80,6 +79,11 @@ int main (int argc, char **argv) {
 		return -1;
 	}
 	
+	if(ioctl(fd, FE_SET_VOLTAGE, SEC_VOLTAGE_13))	{
+	    printf("problem Setting the Voltage\n");
+	    return -1;
+	}
+	usleep(2000000);
 	while(fgets(buf, sizeof(buf), in) && (!dsend(fd, buf))) {
 	}
 	if(ferror(in)) {


### PR DESCRIPTION
Without that modification my matrix switch is not programmed in my environment (DM900 attached via a 10m cable to Inverto UWT110-CUO1O-32P). With the modification my DM900 can successfully program my inverto matrix. I think it would be  good idea to have this merged.